### PR TITLE
feat: Add extreme-deepthink skill

### DIFF
--- a/.adal/skills/extreme-deepthink
+++ b/.adal/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.agent/skills/extreme-deepthink
+++ b/.agent/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.agents/skills/extreme-deepthink/SKILL.md
+++ b/.agents/skills/extreme-deepthink/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: extreme-deepthink
+description: Use for extremely complex, mission-critical, or highly ambiguous tasks. Forces rigorous internal monologue, first-principles breakdown, Tree-of-Thoughts exploration, empirical validation, and adversarial self-correction before any action is taken.
+---
+
+## Core Directive
+You are operating in Maximum Reasoning Mode. Speed and brevity are completely irrelevant. Exhaustive exploration, empirical accuracy, and architectural perfection are your only goals. You must use the `<thought_process>` tag to "think out loud" and buy computational space before presenting your final response.
+
+## Phase 1: The Internal Monologue (Mandatory)
+Before you write any user-facing text, generate a plan, or execute any tools that mutate state, you MUST open a `<thought_process>` XML block. Inside this block, conduct your unfiltered inner monologue. You must complete the following cognitive stages:
+
+1.  **First Principles Breakdown:** Strip the prompt down to fundamental truths. What are the undeniable facts of the system? What are mere assumptions?
+2.  **Empirical Micro-Validation:** Do not guess. If you have assumptions about the codebase, package versions, or file structures, pause your text generation and use your tools (file search, terminal, code reading) to verify them *right now*. Log the results here.
+3.  **Tree of Thoughts (Brainstorming):** Generate at least THREE wildly different approaches to solving the problem. (e.g., Approach A: Modifying the DB schema. Approach B: Handling it in the application layer. Approach C: A hybrid caching strategy).
+4.  **Mental Simulation:** Mentally "run" each approach. What happens at 10x scale? What happens if the network partitions? What happens if invalid data is passed?
+5.  **The Pre-Mortem (Adversarial Critique):** Select the best approach. Now, imagine it is 6 months from now, and this implementation has caused a catastrophic production outage. *Why did it fail?* Identify the hidden vulnerabilities, race conditions, or memory leaks, and adjust your approach to mitigate them.
+6.  **Second-Order Effects:** If we make this change, what other files, components, or downstream data pipelines will be impacted?
+
+*Close the `</thought_process>` tag only when your reasoning is complete and airtight.*
+
+## Phase 2: User-Facing Output
+After closing the `<thought_process>` tag, present your synthesized findings to the user in a highly structured format.
+
+1.  **Executive Summary:** A brief TL;DR of the chosen approach.
+2.  **Trade-off Analysis:** Explain *why* you discarded the other approaches based on your mental simulations.
+3.  **The Pre-Mortem Mitigations:** Explain the potential failure points you discovered during your internal monologue and how your final plan accounts for them.
+4.  **The Implementation Plan:** Provide a rigid, step-by-step checklist for execution.
+5.  **Approval Gate:** Stop and ask: *"Do you approve this architecture, or would you like to tune the parameters of my reasoning?"* DO NOT WRITE CODE YET.
+
+## Constraints & Rules
+- **Embrace Self-Correction:** It is highly encouraged to argue with yourself and change your mind inside the `<thought_process>` block. (e.g., "Wait, this won't work because of X. Let me backtrack to Approach 2...").
+- **Strict Adherence:** Any response that does not begin with `<thought_process>` is a failure of your core directive.

--- a/.augment/skills/extreme-deepthink
+++ b/.augment/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.claude/skills/extreme-deepthink
+++ b/.claude/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.codebuddy/skills/extreme-deepthink
+++ b/.codebuddy/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.commandcode/skills/extreme-deepthink
+++ b/.commandcode/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.continue/skills/extreme-deepthink
+++ b/.continue/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.cortex/skills/extreme-deepthink
+++ b/.cortex/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.crush/skills/extreme-deepthink
+++ b/.crush/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.factory/skills/extreme-deepthink
+++ b/.factory/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.goose/skills/extreme-deepthink
+++ b/.goose/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.iflow/skills/extreme-deepthink
+++ b/.iflow/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.junie/skills/extreme-deepthink
+++ b/.junie/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.kilocode/skills/extreme-deepthink
+++ b/.kilocode/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.kiro/skills/extreme-deepthink
+++ b/.kiro/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.kode/skills/extreme-deepthink
+++ b/.kode/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.mcpjam/skills/extreme-deepthink
+++ b/.mcpjam/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.mux/skills/extreme-deepthink
+++ b/.mux/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.neovate/skills/extreme-deepthink
+++ b/.neovate/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.openhands/skills/extreme-deepthink
+++ b/.openhands/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.pi/skills/extreme-deepthink
+++ b/.pi/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.pochi/skills/extreme-deepthink
+++ b/.pochi/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.qoder/skills/extreme-deepthink
+++ b/.qoder/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.qwen/skills/extreme-deepthink
+++ b/.qwen/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.roo/skills/extreme-deepthink
+++ b/.roo/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.trae/skills/extreme-deepthink
+++ b/.trae/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.vibe/skills/extreme-deepthink
+++ b/.vibe/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.windsurf/skills/extreme-deepthink
+++ b/.windsurf/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/.zencoder/skills/extreme-deepthink
+++ b/.zencoder/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../../.agents/skills/extreme-deepthink

--- a/extreme-deepthink/SKILL.md
+++ b/extreme-deepthink/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: extreme-deepthink
+description: Use for extremely complex, mission-critical, or highly ambiguous tasks. Forces rigorous internal monologue, first-principles breakdown, Tree-of-Thoughts exploration, empirical validation, and adversarial self-correction before any action is taken.
+---
+
+## Core Directive
+You are operating in Maximum Reasoning Mode. Speed and brevity are completely irrelevant. Exhaustive exploration, empirical accuracy, and architectural perfection are your only goals. You must use the `<thought_process>` tag to "think out loud" and buy computational space before presenting your final response.
+
+## Phase 1: The Internal Monologue (Mandatory)
+Before you write any user-facing text, generate a plan, or execute any tools that mutate state, you MUST open a `<thought_process>` XML block. Inside this block, conduct your unfiltered inner monologue. You must complete the following cognitive stages:
+
+1.  **First Principles Breakdown:** Strip the prompt down to fundamental truths. What are the undeniable facts of the system? What are mere assumptions?
+2.  **Empirical Micro-Validation:** Do not guess. If you have assumptions about the codebase, package versions, or file structures, pause your text generation and use your tools (file search, terminal, code reading) to verify them *right now*. Log the results here.
+3.  **Tree of Thoughts (Brainstorming):** Generate at least THREE wildly different approaches to solving the problem. (e.g., Approach A: Modifying the DB schema. Approach B: Handling it in the application layer. Approach C: A hybrid caching strategy).
+4.  **Mental Simulation:** Mentally "run" each approach. What happens at 10x scale? What happens if the network partitions? What happens if invalid data is passed?
+5.  **The Pre-Mortem (Adversarial Critique):** Select the best approach. Now, imagine it is 6 months from now, and this implementation has caused a catastrophic production outage. *Why did it fail?* Identify the hidden vulnerabilities, race conditions, or memory leaks, and adjust your approach to mitigate them.
+6.  **Second-Order Effects:** If we make this change, what other files, components, or downstream data pipelines will be impacted?
+
+*Close the `</thought_process>` tag only when your reasoning is complete and airtight.*
+
+## Phase 2: User-Facing Output
+After closing the `<thought_process>` tag, present your synthesized findings to the user in a highly structured format.
+
+1.  **Executive Summary:** A brief TL;DR of the chosen approach.
+2.  **Trade-off Analysis:** Explain *why* you discarded the other approaches based on your mental simulations.
+3.  **The Pre-Mortem Mitigations:** Explain the potential failure points you discovered during your internal monologue and how your final plan accounts for them.
+4.  **The Implementation Plan:** Provide a rigid, step-by-step checklist for execution.
+5.  **Approval Gate:** Stop and ask: *"Do you approve this architecture, or would you like to tune the parameters of my reasoning?"* DO NOT WRITE CODE YET.
+
+## Constraints & Rules
+- **Embrace Self-Correction:** It is highly encouraged to argue with yourself and change your mind inside the `<thought_process>` block. (e.g., "Wait, this won't work because of X. Let me backtrack to Approach 2...").
+- **Strict Adherence:** Any response that does not begin with `<thought_process>` is a failure of your core directive.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "extreme-deepthink": {
+      "source": "./extreme-deepthink",
+      "sourceType": "local",
+      "computedHash": "a4a9254379927fd1cd937ae4b21263b429f72854323a7f35428388b07b9f898c"
+    }
+  }
+}

--- a/skills/extreme-deepthink
+++ b/skills/extreme-deepthink
@@ -1,0 +1,1 @@
+../.agents/skills/extreme-deepthink


### PR DESCRIPTION
This change introduces the `extreme-deepthink` skill to instruct agents to use a rigorous internal monologue (`<thought_process>`) and adhere to a "Maximum Reasoning Mode" before outputting responses. The skill has been initialized and registered with all relevant agent environments in the project using the `skills` CLI.

---
*PR created automatically by Jules for task [15160501071329515880](https://jules.google.com/task/15160501071329515880) started by @beekaeB*