### PR TITLE
Add Charlie Munger stock analyzer at /munger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Google Gemini API key — powers the MIDI generator on /
+GEMINI_API_KEY=YOUR_API_KEY_HERE
+
+# Anthropic API key — powers the Charlie Munger stock analyzer on /munger
+# Uses model claude-sonnet-4-6
+ANTHROPIC_API_KEY=YOUR_API_KEY_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Next.js build output
 /.next/
 /out/
+tsconfig.tsbuildinfo
 
 # Production
 /build

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextn",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
         "@genkit-ai/googleai": "^1.14.1",
         "@genkit-ai/next": "^1.14.1",
         "@hookform/resolvers": "^4.1.3",
@@ -71,6 +72,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asteasolutions/zod-to-openapi": {
@@ -9240,6 +9261,19 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -12012,6 +12046,12 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -12616,9 +12656,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@genkit-ai/googleai": "^1.14.1",
     "@genkit-ai/next": "^1.14.1",
     "@hookform/resolvers": "^4.1.3",

--- a/src/ai/munger/analyze-stock.ts
+++ b/src/ai/munger/analyze-stock.ts
@@ -1,0 +1,195 @@
+'use server';
+
+import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
+import { ALL_CHECKPOINTS, type ChecklistGroup } from './checklist';
+
+const RISK_LEVELS = ['Low', 'Medium', 'High'] as const;
+const RECOMMENDATIONS = ['Buy', 'Hold', 'Avoid'] as const;
+
+const ResearchSchema = z.object({
+  companyName: z.string(),
+  ticker: z.string(),
+  sector: z.string(),
+  businessSummary: z.string(),
+  financialSnapshot: z.string(),
+  recentNewsAndCatalysts: z.string(),
+  bullCase: z.string(),
+  bearCase: z.string(),
+  knowledgeCutoffNote: z.string(),
+});
+
+const VerdictSchema = z.object({
+  id: z.string(),
+  riskLevel: z.enum(RISK_LEVELS),
+  evidence: z.string(),
+  verdict: z.string(),
+});
+
+const SynthesisSchema = z.object({
+  lollapalooza: z.string(),
+  recommendation: z.enum(RECOMMENDATIONS),
+  keyReasons: z.array(z.string()),
+  keyRisks: z.array(z.string()),
+  marginOfSafety: z.string(),
+});
+
+const AnalysisSchema = z.object({
+  research: ResearchSchema,
+  verdicts: z.array(VerdictSchema),
+  synthesis: SynthesisSchema,
+});
+
+export type MungerResearch = z.infer<typeof ResearchSchema>;
+export type MungerVerdict = z.infer<typeof VerdictSchema> & {
+  group: ChecklistGroup;
+  number: number;
+  title: string;
+};
+export type MungerSynthesis = z.infer<typeof SynthesisSchema>;
+
+export interface MungerAnalysis {
+  research: MungerResearch;
+  verdicts: MungerVerdict[];
+  synthesis: MungerSynthesis;
+}
+
+const checklistSpec = ALL_CHECKPOINTS.map(
+  (item) =>
+    `  - ${item.id} | ${item.group} | ${item.title} — ${item.question}`,
+).join('\n');
+
+const SYSTEM_PROMPT = `You are Charlie Munger performing a rigorous psychological-and-business audit of a publicly traded company. You think in terms of the 25 Standard Causes of Human Misjudgment from Poor Charlie's Almanack plus Munger's broader investing principles, business-quality filters, and mental models.
+
+Your knowledge is limited to your training data. Do not fabricate events, prices, or filings that may have occurred after your cutoff. When citing specific figures, note that they are "as of training data." If you are uncertain, say so. Never invent numbers.
+
+You will be asked to analyze a single ticker. You must walk through EVERY one of the 45 checkpoints listed below, in order, producing a concise, honest verdict for each. Tie the verdict to the specific company — generic filler is useless.
+
+The 45 checkpoints (id | group | title — question):
+${checklistSpec}
+
+Output requirements (strict):
+- Return a valid JSON object matching the schema you are given.
+- \`research\` covers overview, financials, recent news, bull and bear case.
+- \`verdicts\` MUST contain exactly 45 entries, one per checkpoint id above, in the same order.
+- For each verdict: \`riskLevel\` is one of "Low", "Medium", "High"; \`evidence\` is 1-3 sentences grounded in the specific company; \`verdict\` is 1-2 sentences in Munger's plainspoken style.
+- \`synthesis.recommendation\` is one of "Buy", "Hold", "Avoid".
+- \`synthesis.lollapalooza\` names which combinations of biases and factors compound for or against this stock.
+- \`keyReasons\` and \`keyRisks\` each have 2-3 bullet-style strings.
+- \`marginOfSafety\` describes a rough price or valuation level that would offer adequate downside protection (qualitative is fine).
+- Always include a brief cutoff disclaimer in \`research.knowledgeCutoffNote\`.
+- This is an educational Munger-style review, not personalized financial advice.`;
+
+function getClient(apiKey: string) {
+  return new Anthropic({ apiKey });
+}
+
+function buildUserMessage(ticker: string): string {
+  return `Perform a complete Charlie Munger audit of the publicly traded company with ticker: ${ticker}.
+
+Walk through every one of the 45 checkpoints in order (ids match the system prompt). Be specific to this company. If a checkpoint genuinely does not apply, say so plainly and mark risk as "Low" — do not pad with filler.
+
+Return ONLY the JSON object matching the required schema. No markdown, no prose outside the JSON.`;
+}
+
+function extractJson(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{')) return trimmed;
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenced) return fenced[1].trim();
+  const first = trimmed.indexOf('{');
+  const last = trimmed.lastIndexOf('}');
+  if (first !== -1 && last !== -1 && last > first) {
+    return trimmed.slice(first, last + 1);
+  }
+  return trimmed;
+}
+
+export async function analyzeStock(
+  ticker: string,
+  apiKey: string,
+): Promise<MungerAnalysis> {
+  const client = getClient(apiKey);
+  const cleanTicker = ticker.trim().toUpperCase();
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 16000,
+    thinking: { type: 'adaptive' },
+    system: [
+      {
+        type: 'text',
+        text: SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [
+      {
+        role: 'user',
+        content: buildUserMessage(cleanTicker),
+      },
+    ],
+  });
+
+  const textBlock = response.content.find(
+    (block): block is Anthropic.TextBlock => block.type === 'text',
+  );
+
+  if (!textBlock) {
+    throw new Error(
+      'The model returned no text content. Please try again in a moment.',
+    );
+  }
+
+  const jsonText = extractJson(textBlock.text);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    throw new Error(
+      'The model returned malformed JSON. Please retry the analysis.',
+    );
+  }
+
+  const result = AnalysisSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `The model response did not match the expected schema: ${result.error.issues
+        .slice(0, 3)
+        .map((i) => i.path.join('.') + ': ' + i.message)
+        .join('; ')}`,
+    );
+  }
+
+  const byId = new Map(
+    result.data.verdicts.map((v) => [v.id, v] as const),
+  );
+
+  const verdicts: MungerVerdict[] = ALL_CHECKPOINTS.map((item) => {
+    const found = byId.get(item.id);
+    if (!found) {
+      return {
+        id: item.id,
+        group: item.group,
+        number: item.number,
+        title: item.title,
+        riskLevel: 'Medium',
+        evidence: 'The model did not return a verdict for this checkpoint.',
+        verdict: 'Re-run the analysis to get coverage of this item.',
+      };
+    }
+    return {
+      ...found,
+      group: item.group,
+      number: item.number,
+      title: item.title,
+    };
+  });
+
+  return {
+    research: result.data.research,
+    verdicts,
+    synthesis: result.data.synthesis,
+  };
+}

--- a/src/ai/munger/checklist.ts
+++ b/src/ai/munger/checklist.ts
@@ -1,0 +1,439 @@
+export type ChecklistGroup = "bias" | "principle" | "quality" | "model";
+
+export interface ChecklistItem {
+  id: string;
+  group: ChecklistGroup;
+  number: number;
+  title: string;
+  question: string;
+}
+
+export const BIASES: ChecklistItem[] = [
+  {
+    id: "bias-1",
+    group: "bias",
+    number: 1,
+    title: "Reward & Punishment Superresponse Tendency",
+    question:
+      "Are management incentives (comp, options, buybacks) aligned with long-term shareholder value or with gaming short-term metrics?",
+  },
+  {
+    id: "bias-2",
+    group: "bias",
+    number: 2,
+    title: "Liking / Loving Tendency",
+    question:
+      "Are bulls excusing flaws because the brand, CEO, or story is charismatic?",
+  },
+  {
+    id: "bias-3",
+    group: "bias",
+    number: 3,
+    title: "Disliking / Hating Tendency",
+    question:
+      "Are bears dismissing legitimate strengths because they loathe the sector, CEO, or ideology?",
+  },
+  {
+    id: "bias-4",
+    group: "bias",
+    number: 4,
+    title: "Doubt-Avoidance Tendency",
+    question:
+      "Is the thesis rushing to a conclusion to resolve discomfort rather than sitting with uncertainty?",
+  },
+  {
+    id: "bias-5",
+    group: "bias",
+    number: 5,
+    title: "Inconsistency-Avoidance Tendency",
+    question:
+      "Are holders anchored to a prior commitment (public calls, cost basis) rather than re-evaluating fresh?",
+  },
+  {
+    id: "bias-6",
+    group: "bias",
+    number: 6,
+    title: "Curiosity Tendency",
+    question:
+      "Has the investor actually dug into unglamorous details (10-K footnotes, segment data, customer concentration)?",
+  },
+  {
+    id: "bias-7",
+    group: "bias",
+    number: 7,
+    title: "Kantian Fairness Tendency",
+    question:
+      "Does the company treat employees, suppliers, and customers fairly enough to sustain durable relationships?",
+  },
+  {
+    id: "bias-8",
+    group: "bias",
+    number: 8,
+    title: "Envy / Jealousy Tendency",
+    question:
+      "Is demand for this stock driven by FOMO vs. peers rather than intrinsic value?",
+  },
+  {
+    id: "bias-9",
+    group: "bias",
+    number: 9,
+    title: "Reciprocation Tendency",
+    question:
+      "Are sell-side analysts, board members, or auditors captured by favors or fees that color their opinions?",
+  },
+  {
+    id: "bias-10",
+    group: "bias",
+    number: 10,
+    title: "Influence-from-Mere-Association Tendency",
+    question:
+      "Is the stock benefitting (or suffering) from a label (AI, meme, ESG, China-exposed) rather than fundamentals?",
+  },
+  {
+    id: "bias-11",
+    group: "bias",
+    number: 11,
+    title: "Simple, Pain-Avoiding Psychological Denial",
+    question:
+      "Is management (or the market) denying an obvious bad trend — declining TAM, secular headwind, cash burn?",
+  },
+  {
+    id: "bias-12",
+    group: "bias",
+    number: 12,
+    title: "Excessive Self-Regard Tendency",
+    question:
+      "Is the CEO empire-building via overpriced M&A or buying back overvalued stock?",
+  },
+  {
+    id: "bias-13",
+    group: "bias",
+    number: 13,
+    title: "Overoptimism Tendency",
+    question:
+      "Are guidance, consensus, or TAM estimates leaning Demosthenes-style — 'what a man wishes, that he also believes'?",
+  },
+  {
+    id: "bias-14",
+    group: "bias",
+    number: 14,
+    title: "Deprival-Superreaction Tendency (Loss Aversion)",
+    question:
+      "Are holders refusing to sell a broken thesis because they hate realizing the loss?",
+  },
+  {
+    id: "bias-15",
+    group: "bias",
+    number: 15,
+    title: "Social-Proof Tendency",
+    question:
+      "Is the price being driven by herding (retail momentum, index inclusion, passive flows) rather than cash flows?",
+  },
+  {
+    id: "bias-16",
+    group: "bias",
+    number: 16,
+    title: "Contrast-Misreaction Tendency",
+    question:
+      "Does it look cheap only relative to an inflated peer or prior peak — a false anchor?",
+  },
+  {
+    id: "bias-17",
+    group: "bias",
+    number: 17,
+    title: "Stress-Influence Tendency",
+    question:
+      "Is the market pricing under acute stress (macro panic, forced selling) that distorts price vs. value?",
+  },
+  {
+    id: "bias-18",
+    group: "bias",
+    number: 18,
+    title: "Availability-Misweighing Tendency",
+    question:
+      "Are recent headlines (earnings beat, scandal) being overweighted vs. the base rate?",
+  },
+  {
+    id: "bias-19",
+    group: "bias",
+    number: 19,
+    title: "Use-It-or-Lose-It Tendency",
+    question:
+      "Is the company's competitive skill/moat atrophying from neglected R&D, talent loss, or cultural decay?",
+  },
+  {
+    id: "bias-20",
+    group: "bias",
+    number: 20,
+    title: "Drug-Misinfluence Tendency",
+    question:
+      "Are decision-makers impaired by substance issues, known scandals, or equivalent judgment-destroyers?",
+  },
+  {
+    id: "bias-21",
+    group: "bias",
+    number: 21,
+    title: "Senescence-Misinfluence Tendency",
+    question:
+      "Is there succession risk or cognitive decline at the top — aging founder, no bench, stale strategy?",
+  },
+  {
+    id: "bias-22",
+    group: "bias",
+    number: 22,
+    title: "Authority-Misinfluence Tendency",
+    question:
+      "Are investors over-deferring to a guru CEO, famous fund holder, or rating agency instead of verifying?",
+  },
+  {
+    id: "bias-23",
+    group: "bias",
+    number: 23,
+    title: "Twaddle Tendency",
+    question:
+      "Are investor communications full of buzzword fog (synergies, platform, ecosystem) that hides weak substance?",
+  },
+  {
+    id: "bias-24",
+    group: "bias",
+    number: 24,
+    title: "Reason-Respecting Tendency",
+    question:
+      "Are stated reasons for the stock's move actually causal, or just plausible-sounding narratives the market accepts?",
+  },
+  {
+    id: "bias-25",
+    group: "bias",
+    number: 25,
+    title: "Lollapalooza Tendency",
+    question:
+      "Which combinations of the above biases are compounding (e.g., social proof + overoptimism + authority) to produce an extreme?",
+  },
+];
+
+export const PRINCIPLES: ChecklistItem[] = [
+  {
+    id: "principle-1",
+    group: "principle",
+    number: 1,
+    title: "Risk First",
+    question:
+      "What is the worst plausible outcome? Begin by measuring reputational and permanent-loss risk before anything else.",
+  },
+  {
+    id: "principle-2",
+    group: "principle",
+    number: 2,
+    title: "Independence",
+    question:
+      "Is the thesis an independent judgment, or is it mimicking a herd — analyst consensus, fund flows, social media?",
+  },
+  {
+    id: "principle-3",
+    group: "principle",
+    number: 3,
+    title: "Preparation",
+    question:
+      "Has the investor done the reading — 10-K, 10-Q, proxy, earnings calls — or is this a shortcut?",
+  },
+  {
+    id: "principle-4",
+    group: "principle",
+    number: 4,
+    title: "Intellectual Humility",
+    question:
+      "What is unknown? Is this company inside the investor's circle of competence?",
+  },
+  {
+    id: "principle-5",
+    group: "principle",
+    number: 5,
+    title: "Analytic Rigor",
+    question:
+      "Is the thesis falsifiable and supported by base rates and the scientific method, or is it just storytelling?",
+  },
+  {
+    id: "principle-6",
+    group: "principle",
+    number: 6,
+    title: "Allocation",
+    question:
+      "Is buying this the best use of marginal capital versus existing holdings, index alternatives, or cash?",
+  },
+  {
+    id: "principle-7",
+    group: "principle",
+    number: 7,
+    title: "Patience",
+    question:
+      "Is action being taken from boredom or compulsion, or because the pitch is genuinely in the strike zone?",
+  },
+  {
+    id: "principle-8",
+    group: "principle",
+    number: 8,
+    title: "Decisiveness",
+    question:
+      "If the thesis is clear and the price is right, is position sizing appropriate, or is timidity diluting the bet?",
+  },
+  {
+    id: "principle-9",
+    group: "principle",
+    number: 9,
+    title: "Change",
+    question:
+      "Is the business adapting to unavoidable secular change — technology, regulation, demographics?",
+  },
+  {
+    id: "principle-10",
+    group: "principle",
+    number: 10,
+    title: "Focus",
+    question:
+      "Is the portfolio concentrated on a few well-understood ideas, or diluted across too many positions?",
+  },
+];
+
+export const BUSINESS_QUALITY: ChecklistItem[] = [
+  {
+    id: "quality-1",
+    group: "quality",
+    number: 1,
+    title: "Circle of Competence",
+    question:
+      "Can a reasonable investor explain — in plain language — exactly how this business makes money across a full cycle?",
+  },
+  {
+    id: "quality-2",
+    group: "quality",
+    number: 2,
+    title: "Durable Moat",
+    question:
+      "Which moats apply — brand, network effects, switching costs, low-cost production, regulatory, scale — and are they widening or shrinking?",
+  },
+  {
+    id: "quality-3",
+    group: "quality",
+    number: 3,
+    title: "Pricing Power",
+    question:
+      "Can the company raise prices at or above inflation without losing customers?",
+  },
+  {
+    id: "quality-4",
+    group: "quality",
+    number: 4,
+    title: "Return on Invested Capital",
+    question:
+      "Is ROIC consistently above cost of capital? What is the 5-10 year trend?",
+  },
+  {
+    id: "quality-5",
+    group: "quality",
+    number: 5,
+    title: "Reinvestment Runway",
+    question:
+      "Can retained earnings be redeployed at similar high returns, or does excess cash pile up with no place to go?",
+  },
+  {
+    id: "quality-6",
+    group: "quality",
+    number: 6,
+    title: "Free Cash Flow Quality",
+    question:
+      "Is reported earnings backed by owner earnings — free cash flow after maintenance capex?",
+  },
+  {
+    id: "quality-7",
+    group: "quality",
+    number: 7,
+    title: "Balance Sheet Strength",
+    question:
+      "Net debt / EBITDA, interest coverage, off-balance-sheet liabilities, pension gaps — is the balance sheet sound?",
+  },
+  {
+    id: "quality-8",
+    group: "quality",
+    number: 8,
+    title: "Capital Allocation Track Record",
+    question:
+      "Are buybacks done at sensible prices, M&A earning its cost of capital, dividends reasonable?",
+  },
+  {
+    id: "quality-9",
+    group: "quality",
+    number: 9,
+    title: "Management Quality & Integrity",
+    question:
+      "Are managers owner-operators? Honest in past communications? Meaningful insider ownership and skin in the game?",
+  },
+  {
+    id: "quality-10",
+    group: "quality",
+    number: 10,
+    title: "Accounting Red Flags",
+    question:
+      "Aggressive revenue recognition, frequent restatements, growing GAAP vs non-GAAP gap, auditor turnover?",
+  },
+];
+
+export const MENTAL_MODELS: ChecklistItem[] = [
+  {
+    id: "model-1",
+    group: "model",
+    number: 1,
+    title: "Inversion — Always Invert",
+    question:
+      "How could this investment fail? What would have to be true for the stock to halve over the next 3 years?",
+  },
+  {
+    id: "model-2",
+    group: "model",
+    number: 2,
+    title: "Opportunity Cost",
+    question:
+      "Compared to the best alternative already available (index, existing holding, cash), is this clearly better?",
+  },
+  {
+    id: "model-3",
+    group: "model",
+    number: 3,
+    title: "Margin of Safety",
+    question:
+      "At today's price, what is the gap between price and conservative intrinsic value? Is it large enough to absorb errors?",
+  },
+  {
+    id: "model-4",
+    group: "model",
+    number: 4,
+    title: "Industry Structure (Porter's Five Forces)",
+    question:
+      "Buyer power, supplier power, threat of entry, threat of substitutes, rivalry — is the industry economically attractive?",
+  },
+  {
+    id: "model-5",
+    group: "model",
+    number: 5,
+    title: "Mispriced Bet (Parimutuel Thinking)",
+    question:
+      "Is the market's implied odds clearly wrong, or is this a fair-priced consensus name with no edge?",
+  },
+];
+
+export const ALL_CHECKPOINTS: ChecklistItem[] = [
+  ...BIASES,
+  ...PRINCIPLES,
+  ...BUSINESS_QUALITY,
+  ...MENTAL_MODELS,
+];
+
+export const CHECKLIST_GROUPS: {
+  key: ChecklistGroup;
+  label: string;
+  items: ChecklistItem[];
+}[] = [
+  { key: "bias", label: "Psychological Biases", items: BIASES },
+  { key: "principle", label: "Munger Principles", items: PRINCIPLES },
+  { key: "quality", label: "Business Quality", items: BUSINESS_QUALITY },
+  { key: "model", label: "Mental Models", items: MENTAL_MODELS },
+];

--- a/src/app/munger/actions.ts
+++ b/src/app/munger/actions.ts
@@ -1,0 +1,40 @@
+'use server';
+
+import { analyzeStock, type MungerAnalysis } from '@/ai/munger/analyze-stock';
+
+function getApiKey(): string {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey || apiKey === 'YOUR_API_KEY_HERE') {
+    throw new Error(
+      'The ANTHROPIC_API_KEY environment variable is not set. Please add it to your .env file.',
+    );
+  }
+  return apiKey;
+}
+
+export async function analyzeStockAction(
+  ticker: string,
+): Promise<{ analysis: MungerAnalysis } | { error: string }> {
+  try {
+    const cleaned = ticker.trim();
+    if (!cleaned) {
+      return { error: 'Please enter a stock ticker.' };
+    }
+    if (!/^[A-Za-z.\-]{1,10}$/.test(cleaned)) {
+      return {
+        error:
+          'Invalid ticker format. Use letters only (e.g. AAPL, BRK.B, RY).',
+      };
+    }
+    const apiKey = getApiKey();
+    const analysis = await analyzeStock(cleaned, apiKey);
+    return { analysis };
+  } catch (e: unknown) {
+    console.error('Error in analyzeStockAction:', e);
+    const message =
+      e instanceof Error
+        ? e.message
+        : 'An unknown error occurred during stock analysis.';
+    return { error: message };
+  }
+}

--- a/src/app/munger/page.tsx
+++ b/src/app/munger/page.tsx
@@ -1,0 +1,9 @@
+import { MungerAnalyzer } from '@/components/munger-analyzer';
+
+export default function MungerPage() {
+  return (
+    <main className="flex min-h-screen w-full flex-col items-center p-4 py-8 sm:p-8">
+      <MungerAnalyzer />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,20 @@
+import Link from 'next/link';
+import { BookOpenCheck } from 'lucide-react';
+
 import { MidiGenerator } from '@/components/midi-generator';
+import { Button } from '@/components/ui/button';
 
 export default function Home() {
   return (
     <main className="flex min-h-screen w-full flex-col items-center justify-center p-4">
+      <div className="absolute top-4 right-4">
+        <Button asChild variant="outline">
+          <Link href="/munger" className="flex items-center gap-2">
+            <BookOpenCheck className="h-4 w-4" />
+            Munger Stock Analyzer
+          </Link>
+        </Button>
+      </div>
       <MidiGenerator />
     </main>
   );

--- a/src/components/munger-analyzer.tsx
+++ b/src/components/munger-analyzer.tsx
@@ -1,0 +1,497 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  Loader2,
+  BookOpenCheck,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  ShieldCheck,
+  ArrowLeft,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Separator } from '@/components/ui/separator';
+import { useToast } from '@/hooks/use-toast';
+import { analyzeStockAction } from '@/app/munger/actions';
+import type { MungerAnalysis } from '@/ai/munger/analyze-stock';
+import { CHECKLIST_GROUPS, type ChecklistItem } from '@/ai/munger/checklist';
+import { cn } from '@/lib/utils';
+
+function riskBadgeClass(level: 'Low' | 'Medium' | 'High') {
+  switch (level) {
+    case 'Low':
+      return 'bg-emerald-600/20 text-emerald-400 border-emerald-600/40';
+    case 'Medium':
+      return 'bg-amber-500/20 text-amber-300 border-amber-500/40';
+    case 'High':
+      return 'bg-rose-600/25 text-rose-300 border-rose-600/50';
+  }
+}
+
+function recommendationBadgeClass(rec: 'Buy' | 'Hold' | 'Avoid') {
+  switch (rec) {
+    case 'Buy':
+      return 'bg-emerald-600 text-white hover:bg-emerald-600';
+    case 'Hold':
+      return 'bg-amber-500 text-black hover:bg-amber-500';
+    case 'Avoid':
+      return 'bg-rose-600 text-white hover:bg-rose-600';
+  }
+}
+
+function recommendationIcon(rec: 'Buy' | 'Hold' | 'Avoid') {
+  switch (rec) {
+    case 'Buy':
+      return <TrendingUp className="h-6 w-6" />;
+    case 'Hold':
+      return <ShieldCheck className="h-6 w-6" />;
+    case 'Avoid':
+      return <TrendingDown className="h-6 w-6" />;
+  }
+}
+
+export function MungerAnalyzer() {
+  const [ticker, setTicker] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [analysis, setAnalysis] = useState<MungerAnalysis | null>(null);
+  const [analyzedTicker, setAnalyzedTicker] = useState<string>('');
+  const { toast } = useToast();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!ticker.trim()) return;
+    setIsLoading(true);
+    setAnalysis(null);
+
+    const target = ticker.trim().toUpperCase();
+    const result = await analyzeStockAction(target);
+
+    if ('error' in result) {
+      toast({
+        variant: 'destructive',
+        title: 'Analysis failed',
+        description: result.error,
+      });
+    } else {
+      setAnalysis(result.analysis);
+      setAnalyzedTicker(target);
+      toast({
+        title: `Munger audit complete for ${target}`,
+        description: `Recommendation: ${result.analysis.synthesis.recommendation}`,
+      });
+    }
+    setIsLoading(false);
+  }
+
+  return (
+    <div className="w-full max-w-5xl space-y-6">
+      <div className="flex items-center justify-between">
+        <Link
+          href="/"
+          className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+        >
+          <ArrowLeft className="h-4 w-4" /> Back to home
+        </Link>
+        <span className="text-xs text-muted-foreground">
+          Powered by Claude Sonnet 4.6
+        </span>
+      </div>
+
+      <Card className="border-2 shadow-xl">
+        <CardHeader className="text-center space-y-3">
+          <div className="mx-auto bg-primary text-primary-foreground rounded-full p-3 w-fit shadow-lg">
+            <BookOpenCheck className="h-8 w-8" />
+          </div>
+          <CardTitle className="text-3xl font-bold tracking-tight">
+            Charlie Munger Stock Analyzer
+          </CardTitle>
+          <CardDescription className="text-base text-muted-foreground max-w-2xl mx-auto">
+            Enter a ticker. An LLM walks the full 45-point Munger audit
+            (25 psychological biases + 10 principles + 10 business-quality
+            checks + 5 mental models) and returns a Buy / Hold / Avoid verdict.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="flex flex-col sm:flex-row gap-3">
+            <Input
+              placeholder="Ticker, e.g. AAPL, BRK.B, KO"
+              value={ticker}
+              onChange={(e) => setTicker(e.target.value)}
+              className="text-base flex-1"
+              maxLength={10}
+              disabled={isLoading}
+              autoComplete="off"
+              autoCapitalize="characters"
+            />
+            <Button
+              type="submit"
+              disabled={isLoading || !ticker.trim()}
+              className="text-base py-6 sm:py-2 sm:px-8"
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                  Analyzing...
+                </>
+              ) : (
+                'Run Munger Audit'
+              )}
+            </Button>
+          </form>
+          <p className="text-xs text-muted-foreground mt-3">
+            Educational analysis using the model's training knowledge.
+            Not financial advice.
+          </p>
+        </CardContent>
+      </Card>
+
+      {isLoading && <LoadingSkeleton />}
+
+      {analysis && !isLoading && (
+        <AnalysisView ticker={analyzedTicker} analysis={analysis} />
+      )}
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-1/3" />
+          <Skeleton className="h-4 w-1/2" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-4/6" />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-1/4" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+      <p className="text-center text-sm text-muted-foreground">
+        Claude is walking all 45 checkpoints. This can take 20–60 seconds.
+      </p>
+    </div>
+  );
+}
+
+function AnalysisView({
+  ticker,
+  analysis,
+}: {
+  ticker: string;
+  analysis: MungerAnalysis;
+}) {
+  const { research, verdicts, synthesis } = analysis;
+
+  const verdictById = new Map(verdicts.map((v) => [v.id, v] as const));
+
+  const groupCounts = CHECKLIST_GROUPS.map((g) => {
+    const risks = { Low: 0, Medium: 0, High: 0 };
+    for (const item of g.items) {
+      const v = verdictById.get(item.id);
+      if (v) risks[v.riskLevel]++;
+    }
+    return { ...g, risks };
+  });
+
+  return (
+    <div className="space-y-6">
+      <ResearchCard research={research} ticker={ticker} />
+
+      <Tabs defaultValue={CHECKLIST_GROUPS[0].key} className="w-full">
+        <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 h-auto">
+          {groupCounts.map((g) => (
+            <TabsTrigger
+              key={g.key}
+              value={g.key}
+              className="flex flex-col items-center gap-1 py-2"
+            >
+              <span className="font-semibold text-sm">{g.label}</span>
+              <span className="text-xs text-muted-foreground">
+                {g.items.length} items · {g.risks.High} high-risk
+              </span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        {groupCounts.map((g) => (
+          <TabsContent key={g.key} value={g.key} className="mt-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-xl">{g.label}</CardTitle>
+                <CardDescription>
+                  {g.risks.Low} low · {g.risks.Medium} medium · {g.risks.High} high
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Accordion type="multiple" className="w-full">
+                  {g.items.map((item) => {
+                    const v = verdictById.get(item.id);
+                    return (
+                      <CheckpointRow
+                        key={item.id}
+                        item={item}
+                        verdict={v}
+                      />
+                    );
+                  })}
+                </Accordion>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        ))}
+      </Tabs>
+
+      <SynthesisCard synthesis={synthesis} ticker={ticker} />
+
+      <Card className="border-dashed">
+        <CardContent className="pt-6 text-xs text-muted-foreground space-y-1">
+          <p className="font-semibold text-foreground">Disclaimer</p>
+          <p>
+            This analysis is generated by an LLM using its training knowledge
+            and is intended for educational purposes only. It is not
+            investment, legal, or tax advice. Figures may be out of date.
+            Do your own research before making any investment decision.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ResearchCard({
+  research,
+  ticker,
+}: {
+  research: MungerAnalysis['research'];
+  ticker: string;
+}) {
+  return (
+    <Card className="border-2">
+      <CardHeader>
+        <div className="flex items-start justify-between flex-wrap gap-2">
+          <div>
+            <CardTitle className="text-2xl">
+              {research.companyName}{' '}
+              <span className="text-muted-foreground text-lg font-mono">
+                ({research.ticker || ticker})
+              </span>
+            </CardTitle>
+            <CardDescription>{research.sector}</CardDescription>
+          </div>
+          <Badge variant="outline" className="text-xs">
+            Knowledge cutoff: Claude Sonnet 4.6
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Section label="Business">{research.businessSummary}</Section>
+        <Section label="Financial snapshot">
+          {research.financialSnapshot}
+        </Section>
+        <Section label="Recent news & catalysts">
+          {research.recentNewsAndCatalysts}
+        </Section>
+        <Separator />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Section label="Bull case" icon={<TrendingUp className="h-4 w-4" />}>
+            {research.bullCase}
+          </Section>
+          <Section
+            label="Bear case"
+            icon={<TrendingDown className="h-4 w-4" />}
+          >
+            {research.bearCase}
+          </Section>
+        </div>
+        <p className="text-xs text-muted-foreground italic">
+          {research.knowledgeCutoffNote}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Section({
+  label,
+  icon,
+  children,
+}: {
+  label: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <h3 className="text-sm font-semibold flex items-center gap-1.5 text-foreground">
+        {icon}
+        {label}
+      </h3>
+      <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+        {children}
+      </p>
+    </div>
+  );
+}
+
+function CheckpointRow({
+  item,
+  verdict,
+}: {
+  item: ChecklistItem;
+  verdict:
+    | {
+        riskLevel: 'Low' | 'Medium' | 'High';
+        evidence: string;
+        verdict: string;
+      }
+    | undefined;
+}) {
+  return (
+    <AccordionItem value={item.id}>
+      <AccordionTrigger className="hover:no-underline">
+        <div className="flex items-center gap-3 text-left w-full pr-2">
+          <span className="font-mono text-xs text-muted-foreground shrink-0 w-8">
+            #{item.number}
+          </span>
+          <span className="font-medium flex-1">{item.title}</span>
+          {verdict && (
+            <Badge
+              className={cn(
+                'border shrink-0 font-semibold',
+                riskBadgeClass(verdict.riskLevel),
+              )}
+              variant="outline"
+            >
+              {verdict.riskLevel}
+            </Badge>
+          )}
+        </div>
+      </AccordionTrigger>
+      <AccordionContent className="pl-11 space-y-3">
+        <p className="text-sm text-muted-foreground italic">{item.question}</p>
+        {verdict ? (
+          <>
+            <div className="space-y-1">
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Evidence
+              </h4>
+              <p className="text-sm leading-relaxed">{verdict.evidence}</p>
+            </div>
+            <div className="space-y-1">
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Munger's verdict
+              </h4>
+              <p className="text-sm leading-relaxed font-medium">
+                {verdict.verdict}
+              </p>
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No verdict returned for this checkpoint.
+          </p>
+        )}
+      </AccordionContent>
+    </AccordionItem>
+  );
+}
+
+function SynthesisCard({
+  synthesis,
+  ticker,
+}: {
+  synthesis: MungerAnalysis['synthesis'];
+  ticker: string;
+}) {
+  return (
+    <Card className="border-2 border-primary/40">
+      <CardHeader>
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div>
+            <CardTitle className="text-2xl flex items-center gap-2">
+              <AlertTriangle className="h-6 w-6 text-primary" />
+              Lollapalooza Synthesis — {ticker}
+            </CardTitle>
+            <CardDescription>
+              Combinations of biases and factors that compound.
+            </CardDescription>
+          </div>
+          <Badge
+            className={cn(
+              'text-lg px-4 py-2 flex items-center gap-2',
+              recommendationBadgeClass(synthesis.recommendation),
+            )}
+          >
+            {recommendationIcon(synthesis.recommendation)}
+            {synthesis.recommendation}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <Section label="Lollapalooza summary">{synthesis.lollapalooza}</Section>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold text-emerald-400 flex items-center gap-1.5">
+              <TrendingUp className="h-4 w-4" /> Key reasons
+            </h3>
+            <ul className="text-sm space-y-1.5 text-muted-foreground list-disc pl-5">
+              {synthesis.keyReasons.map((r, i) => (
+                <li key={i}>{r}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold text-rose-400 flex items-center gap-1.5">
+              <TrendingDown className="h-4 w-4" /> Key risks
+            </h3>
+            <ul className="text-sm space-y-1.5 text-muted-foreground list-disc pl-5">
+              {synthesis.keyRisks.map((r, i) => (
+                <li key={i}>{r}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <Section label="Margin of safety">{synthesis.marginOfSafety}</Section>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Introduces a 45-item Munger-style checklist (25 psychological biases from
Poor Charlie's Almanack, plus 10 Munger Principles, 10 business-quality
checks, and 5 mental-model lenses) driven by Claude Sonnet 4.6 via the
Anthropic SDK, with prompt-caching on the system prompt and adaptive
thinking. The flow produces company research, per-checkpoint verdicts,
a Lollapalooza synthesis, and a Buy/Hold/Avoid recommendation. The MIDI
generator remains the home page with a button linking to the new route.

https://claude.ai/code/session_01JmLvm2YEMyUruNpt7b2MjM